### PR TITLE
setting resource constraints for Elastic pod

### DIFF
--- a/external/elastic/k8s/templates/deployment.yaml
+++ b/external/elastic/k8s/templates/deployment.yaml
@@ -21,6 +21,13 @@ spec:
         - name: {{ .Values.name }}
           image: docker.elastic.co/elasticsearch/elasticsearch:6.4.1
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "1"
+              memory: "1.5Gi"
+            requests:
+              cpu: "25m"
+              memory: "1Gi"
           ports:
             - containerPort: 9200
             - containerPort: 9300


### PR DESCRIPTION
The pod has been evicted repeatedly because of memory utilization. The added constraints should help to schedule the pod to a node with sufficient resources.