### PR TITLE
Update helm blob location

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
       - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
       - apt update && apt install -y kubectl
-      - curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
+      - curl -O https://get.helm.sh/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
       - tar zxf helm-v2.11.0-linux-amd64.tar.gz
       - mv linux-amd64/helm /usr/local/bin/
       - curl -O https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,7 +11,7 @@ phases:
       - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
       - apt update && apt install -y kubectl
-      - curl -O https://get.helm.sh/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
+      - curl -O https://get.helm.sh/helm-v2.11.0-linux-amd64.tar.gz
       - tar zxf helm-v2.11.0-linux-amd64.tar.gz
       - mv linux-amd64/helm /usr/local/bin/
       - curl -O https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator


### PR DESCRIPTION
The URL for obtaining the Helm blob has changed.

https://helm.sh/blog/get-helm-sh/

https://github.com/mozilla-iam/iam-infra/pull/299